### PR TITLE
Fix deprecation issue

### DIFF
--- a/Form/EventListener/QueringFilterSubscriber.php
+++ b/Form/EventListener/QueringFilterSubscriber.php
@@ -10,7 +10,7 @@
 
 namespace IDCI\Bundle\FilterFormBundle\Form\EventListener;
 
-use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvents;
@@ -33,7 +33,7 @@ class QueringFilterSubscriber implements EventSubscriberInterface
         );
     }
 
-    public function updateFilters(DataEvent $event)
+    public function updateFilters(FormEvent $event)
     {
         $data = $event->getData();
         $this->filterManager->setQueryingFilters(self::cleanData($data));


### PR DESCRIPTION
DataEvent has been deprecated in Symfony 2.1 and was removed in 2.3
