### PR TITLE
Fix ChoiceFieldEntityAbstractFilter with single values

### DIFF
--- a/Form/Filter/ChoiceFieldEntityAbstractFilter.php
+++ b/Form/Filter/ChoiceFieldEntityAbstractFilter.php
@@ -45,6 +45,10 @@ abstract class ChoiceFieldEntityAbstractFilter extends EntityFieldAbstractFilter
 
     public function getResultQueryBuilder($data, $qb, $name)
     {
+        if (!is_array($data)) {
+            $data = array($data);
+        }
+        
         $column = sprintf('%s.%s', $name, $this->getEntityFieldName());
         $qb->andWhere($qb->expr()->in($column, $data));
 


### PR DESCRIPTION
ChoiceFieldEntityAbstractFilter produces a broken query when used with option 'multiple' => false, because the QueryBuilder's in() method does not like getting passed strings.
